### PR TITLE
Fix Storybook Config

### DIFF
--- a/.storybook/babel.config.js
+++ b/.storybook/babel.config.js
@@ -1,7 +1,7 @@
 module.exports = {
-	presets: ['@babel/preset-env'],
+	presets: ['@babel/preset-env', '@babel/preset-typescript'],
 	plugins: [
-		['@babel/plugin-proposal-decorators', {decoratorsBeforeExport: true}],
+		['@babel/plugin-proposal-decorators', {legacy: true}],
 		['@babel/plugin-proposal-class-properties', {loose: true}],
 	],
 };


### PR DESCRIPTION
Fixed an issue where components were not being rendered on the Storybook static website (generated by running `npm run build-storybook`).

Updated the `.storybook/babel.config.js` to: 
- Include `@babel/preset-typescript` preset
- Added `{legacy: true}` option on the `@babel/plugin-proposal-decorators` plugin 