### PR TITLE
Update Base Font Default To Match VSCode Base Font Default

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -13,7 +13,6 @@ const createDesignProviderWrapper = story => {
 		'vscode-design-system-provider'
 	);
 	designProvider.setAttribute('use-defaults', '');
-	designProvider.setAttribute('type-ramp-base-font-size', '14');
 	designProvider.appendChild(story);
 	return designProvider;
 };


### PR DESCRIPTION
Update base font size design token default value to be 13px in order to match the default base font size of VSCode.