### PR TITLE
Fix Icon Only Padding In VS Code Link

### DIFF
--- a/src/link/index.ts
+++ b/src/link/index.ts
@@ -34,7 +34,8 @@ export class VSCodeLink extends Anchor {
 		);
 		if (
 			slottedElements.length === 1 &&
-			slottedElements[0] instanceof SVGElement
+			(slottedElements[0] instanceof SVGElement ||
+				slottedElements[0] instanceof HTMLSpanElement)
 		) {
 			this.control.classList.add('icon-only');
 		} else {


### PR DESCRIPTION
Update the VS Code Link `defaultSlottedContentChanged` method so that the `icon-only` class is applied to HTML `span` elements.