### PR TITLE
Remove Appearance Attribute From Text Field

### DIFF
--- a/src/text-field/index.ts
+++ b/src/text-field/index.ts
@@ -1,15 +1,9 @@
-import {attr, customElement} from '@microsoft/fast-element';
+import {customElement} from '@microsoft/fast-element';
 import {
 	TextFieldTemplate as template,
 	TextField,
 } from '@microsoft/fast-foundation';
 import {TextFieldStyles as styles} from './text-field.styles';
-
-/**
- * Text field appearances
- * @public
- */
-export type TextFieldAppearance = 'filled' | 'outline';
 
 /**
  * The VS Code Text Field element. Extends
@@ -31,26 +25,4 @@ export type TextFieldAppearance = 'filled' | 'outline';
 		delegatesFocus: true,
 	},
 })
-export class VSCodeTextField extends TextField {
-	/**
-	 * The appearance of the element.
-	 *
-	 * @remarks
-	 * HTML Attribute: appearance
-	 *
-	 * @public
-	 */
-	@attr
-	public appearance: TextFieldAppearance;
-
-	/**
-	 * @internal
-	 */
-	public connectedCallback() {
-		super.connectedCallback();
-
-		if (!this.appearance) {
-			this.appearance = 'outline';
-		}
-	}
-}
+export class VSCodeTextField extends TextField {}


### PR DESCRIPTION
Remove the unused `appearance` attribute code from the `VSCodeTextField` class.