### PR TITLE
Reduce Input Component Min Width

### DIFF
--- a/src/design-tokens.ts
+++ b/src/design-tokens.ts
@@ -30,7 +30,7 @@ export const fontFamily = create<string>('font-family').withDefault(
 export const fontWeight = create<string>('font-weight').withDefault('400');
 export const inputHeight = create<string>('input-height').withDefault('26');
 export const inputMinWidth = create<string>('input-min-width').withDefault(
-	'250px'
+	'100px'
 );
 
 /**


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests and/or Storybook stories for your feature or bug fix.
-->

### Link to relevant issue

This pull request resolves #194 

### Description of changes

Reduce the value of the `inputMinWidth` design token to be 100px so that input components can fit within the VS Code sidebar view.