### PR TITLE
Update Data Grid Cell Text Overflow Styling

### DIFF
--- a/src/data-grid/data-grid-cell.styles.ts
+++ b/src/data-grid/data-grid-cell.styles.ts
@@ -27,8 +27,10 @@ export const DataGridCellStyles = css`
 		line-height: ${typeRampBaseLineHeight};
 		font-weight: 400;
 		border: solid calc(${borderWidth} * 1px) transparent;
-		overflow: hidden;
 		border-radius: calc(${cornerRadius} * 1px);
+		min-width: 96px;
+		white-space: wrap;
+		overflow-wrap: break-word;
 	}
 	:host(.column-header) {
 		font-weight: 600;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests and/or Storybook stories for your feature or bug fix.
-->

### Link to relevant issue

This pull request resolves #189 

### Description of changes

Remove data grid cell `text-overflow` and `white-space` CSS styling to resolve an accessibility issue where data grid cell text was being truncated and not fully visible when zoomed in.

_Before:_

<img width="1792" alt="Screen Shot 2021-09-20 at 10 35 39 AM" src="https://user-images.githubusercontent.com/39639992/134048095-682a7a87-bb1d-42c3-95e9-6f1da9813b41.png">

_After:_

<img width="1792" alt="Screen Shot 2021-09-20 at 10 35 09 AM" src="https://user-images.githubusercontent.com/39639992/134048129-ea13cd64-89d4-4161-a29f-ed8a566fc7ba.png">

