### PR TITLE
Ensure `vscode-checkbox` uses aria-label

### DIFF
--- a/src/checkbox/index.ts
+++ b/src/checkbox/index.ts
@@ -21,4 +21,20 @@ import {CheckboxStyles as styles} from './checkbox.styles';
 	template,
 	styles,
 })
-export class VSCodeCheckbox extends Checkbox {}
+export class VSCodeCheckbox extends Checkbox {
+	/**
+	 * Component lifecycle method that runs when the component is inserted
+	 * into the DOM.
+	 *
+	 * @internal
+	 */
+	public connectedCallback() {
+		super.connectedCallback();
+		if (this.textContent) {
+			this.setAttribute('aria-label', this.textContent);
+		} else {
+			// Fallback to the label if there is no text content
+			this.setAttribute('aria-label', 'Checkbox');
+		}
+	}
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests and/or Storybook stories for your feature or bug fix.
-->

### Link to relevant issue

This pull request resolves #180 

### Description of changes

Adds `aria-label` element based on the checkbox component's label to ensure it is read by screenreaders.
