### PR TITLE
Ensure `vscode-option` uses aria-label

### DIFF
--- a/src/option/index.ts
+++ b/src/option/index.ts
@@ -30,13 +30,10 @@ export class VSCodeOption extends ListboxOption {
 	 */
 	public connectedCallback() {
 		super.connectedCallback();
-
-		// This will override any usage of the orientation attribute
-		// inherited by the FAST Foundation Tabs component so that
-		// VSCodePanels are always oriented horizontally
 		if (this.textContent) {
 			this.setAttribute('aria-label', this.textContent);
 		} else {
+			// Fallback to the label if there is no text content
 			this.setAttribute('aria-label', 'Option');
 		}
 	}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests and/or Storybook stories for your feature or bug fix.
-->

### Link to relevant issue

This pull request is one of a series of fixes intended to resolve #180.

### Description of changes

Adds aria-label element based on the `Option` component's label to ensure it is read by screenreaders.