### PR TITLE
Ensure `vscode-text-field` and `vscode-text-area` components use aria-labels

### DIFF
--- a/src/text-area/index.ts
+++ b/src/text-area/index.ts
@@ -36,7 +36,7 @@ export class VSCodeTextArea extends TextArea {
 		if (this.textContent) {
 			this.setAttribute('aria-label', this.textContent);
 		} else {
-			//Describe the generic component if no label is provided
+			// Describe the generic component if no label is provided
 			this.setAttribute('aria-label', 'Text area');
 		}
 	}

--- a/src/text-field/index.ts
+++ b/src/text-field/index.ts
@@ -36,7 +36,7 @@ export class VSCodeTextField extends TextField {
 		if (this.textContent) {
 			this.setAttribute('aria-label', this.textContent);
 		} else {
-			//Describe the generic component if no label is provided
+			// Describe the generic component if no label is provided
 			this.setAttribute('aria-label', 'Text field');
 		}
 	}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests and/or Storybook stories for your feature or bug fix.
-->

### Link to relevant issue

This pull request is one of a series of fixes intended to resolve #180.

### Description of changes

Adds aria-label element based on the `vscode-textfield` and `vscode-textarea` component labels to ensure they are read by screen readers.