### PR TITLE
Announce "Loading" from `vscode-progress-ring` when using a screen reader 

### DIFF
--- a/src/progress-ring/index.ts
+++ b/src/progress-ring/index.ts
@@ -40,6 +40,7 @@ export class VSCodeProgressRing extends BaseProgress {
 
 		// Defines a default aria label that screen readers can access
 		this.setAttribute('aria-label', 'Loading');
+		this.setAttribute('aria-live', 'assertive');
 	}
 
 	/**


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests and/or Storybook stories for your feature or bug fix.
-->

### Link to relevant issue

This pull request resolves #187.

### Description of changes

Adds `aria-live="assertive"` with an implicit `role="alert"` to ensure the progress ring announces a loading state when rendered.

<img width="856" alt="CleanShot 2021-10-05 at 10 49 50@2x" src="https://user-images.githubusercontent.com/25163139/136076256-e3f25bea-5c64-4df7-a326-0d1d22e36e29.png">
