### PR TITLE
Fix Checkbox Indicator Not Rendering In Light Themes

### DIFF
--- a/src/checkbox/checkbox.styles.ts
+++ b/src/checkbox/checkbox.styles.ts
@@ -12,12 +12,12 @@ import {
 	checkboxBackground,
 	checkboxBorder,
 	checkboxCornerRadius,
-	checkboxForeground,
 	cornerRadius,
 	designUnit,
 	disabledOpacity,
 	focusBorder,
 	fontFamily,
+	foreground,
 	typeRampBaseFontSize,
 	typeRampBaseLineHeight,
 } from '../design-tokens';
@@ -44,7 +44,7 @@ export const CheckboxStyles = css`
 	}
 	.label {
 		font-family: ${fontFamily};
-		color: ${checkboxForeground};
+		color: ${foreground};
 		padding-inline-start: calc(${designUnit} * 2px + 2px);
 		margin-inline-end: calc(${designUnit} * 2px + 2px);
 		cursor: pointer;
@@ -57,13 +57,13 @@ export const CheckboxStyles = css`
 		width: 100%;
 		height: 100%;
 		display: block;
-		fill: ${checkboxForeground};
+		fill: ${foreground};
 		opacity: 0;
 		pointer-events: none;
 	}
 	.indeterminate-indicator {
 		border-radius: 2px;
-		background: ${checkboxForeground};
+		background: ${foreground};
 		position: absolute;
 		top: 50%;
 		left: 50%;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests and/or Storybook stories for your feature or bug fix.
-->

### Link to relevant issue

This pull request resolves #228 

### Description of changes

Updates the checkbox design token usage so the indeterminate icon is correctly rendered in light themes.