### PR TITLE
Overflow panel content on x-axis as needed

### DIFF
--- a/src/panels/panels.styles.ts
+++ b/src/panels/panels.styles.ts
@@ -22,6 +22,7 @@ export const PanelsStyles = css`
 		color: ${foreground};
 		grid-template-columns: auto 1fr auto;
 		grid-template-rows: auto 1fr;
+		overflow-x: auto;
 	}
 	.tablist {
 		display: grid;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests and/or Storybook stories for your feature or bug fix.
-->

### Link to relevant issue

This pull request resolves an issue related to #189 where the panel contents were overflowing beyond their parent container.

### Description of changes

Adds `overflow-x` to panel container so that the content and tabs scroll if their parent container constrains it to a width that is smaller than itself.

### Example in `all-components` sample

With fix:
<img width="1327" alt="CleanShot 2021-10-19 at 13 31 26@2x" src="https://user-images.githubusercontent.com/25163139/137987797-c104e5bd-d298-4fde-a186-2670e6036f4c.png">

Without fix:
<img width="1432" alt="CleanShot 2021-10-19 at 13 31 36@2x" src="https://user-images.githubusercontent.com/25163139/137987803-67f771c8-09a0-4f7c-8d0e-3c38e4d836e4.png">


