### PR TITLE
Ensure `progress-ring` announces itself with NVDA screen reader

### DIFF
--- a/src/progress-ring/index.ts
+++ b/src/progress-ring/index.ts
@@ -33,6 +33,7 @@ export class ProgressRing extends BaseProgress {
 		// Defines a default aria label that screen readers can access
 		this.setAttribute('aria-label', 'Loading');
 		this.setAttribute('aria-live', 'assertive');
+		this.setAttribute('role', 'alert');
 	}
 
 	/**


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests and/or Storybook stories for your feature or bug fix.
-->

### Link to relevant issue

This pull request resolves #187

### Description of changes

Ensures NVDA screen reader always announces the progress ring when rendered. Previously, the spinner would only announce itself using VoiceOver.
