### PR TITLE
Set Button Max Width

### DIFF
--- a/src/button/button.styles.ts
+++ b/src/button/button.styles.ts
@@ -59,7 +59,7 @@ const BaseButtonStyles = css`
 		justify-content: center;
 		align-items: center;
 		padding: ${buttonPaddingVertical} ${buttonPaddingHorizontal};
-		white-space: nowrap;
+		white-space: wrap;
 		outline: none;
 		text-decoration: none;
 		border: calc(${borderWidth} * 1px) solid ${buttonBorder};
@@ -68,6 +68,7 @@ const BaseButtonStyles = css`
 		fill: inherit;
 		cursor: inherit;
 		font-family: inherit;
+		max-width: 300px;
 	}
 	:host(:hover) {
 		background: ${buttonPrimaryHoverBackground};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests and/or Storybook stories for your feature or bug fix.
-->

### Link to relevant issue

This pull request resolves #227

### Description of changes

Adds a `max-width: 300px` to buttons and sets the `white-space: wrap` so button content doesn't overflow its boundaries.
