### PR TITLE
Add missing type info in component registration functions

### DIFF
--- a/docs/api-report.md
+++ b/docs/api-report.md
@@ -12,14 +12,12 @@ import { Button as Button_2 } from '@microsoft/fast-foundation';
 import { ButtonOptions } from '@microsoft/fast-foundation';
 import { Checkbox as Checkbox_2 } from '@microsoft/fast-foundation';
 import { CheckboxOptions } from '@microsoft/fast-foundation';
-import { Constructable } from '@microsoft/fast-element';
 import type { Container } from '@microsoft/fast-foundation';
 import { DataGrid as DataGrid_2 } from '@microsoft/fast-foundation';
 import { DataGridCell as DataGridCell_2 } from '@microsoft/fast-foundation';
 import { DataGridRow as DataGridRow_2 } from '@microsoft/fast-foundation';
 import { DesignSystem } from '@microsoft/fast-foundation';
 import { Divider as Divider_2 } from '@microsoft/fast-foundation';
-import { FoundationElement } from '@microsoft/fast-foundation';
 import { FoundationElementDefinition } from '@microsoft/fast-foundation';
 import { FoundationElementRegistry } from '@microsoft/fast-foundation';
 import { ListboxOption } from '@microsoft/fast-foundation';
@@ -41,24 +39,24 @@ import { TextFieldOptions } from '@microsoft/fast-foundation';
 // @public
 export const allComponents: {
     vsCodeBadge: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, typeof Badge>;
-    vsCodeButton: (overrideDefinition?: OverrideFoundationElementDefinition<ButtonOptions> | undefined) => FoundationElementRegistry<ButtonOptions, Constructable<FoundationElement>>;
-    vsCodeCheckbox: (overrideDefinition?: OverrideFoundationElementDefinition<CheckboxOptions> | undefined) => FoundationElementRegistry<CheckboxOptions, Constructable<FoundationElement>>;
+    vsCodeButton: (overrideDefinition?: OverrideFoundationElementDefinition<ButtonOptions> | undefined) => FoundationElementRegistry<ButtonOptions, typeof Button>;
+    vsCodeCheckbox: (overrideDefinition?: OverrideFoundationElementDefinition<CheckboxOptions> | undefined) => FoundationElementRegistry<CheckboxOptions, typeof Checkbox>;
     vsCodeDataGrid: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, typeof DataGrid>;
     vsCodeDataGridCell: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, typeof DataGridCell>;
     vsCodeDataGridRow: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, typeof DataGridRow>;
     vsCodeDivider: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, typeof Divider>;
-    vsCodeDropdown: (overrideDefinition?: OverrideFoundationElementDefinition<SelectOptions> | undefined) => FoundationElementRegistry<SelectOptions, Constructable<FoundationElement>>;
-    vsCodeLink: (overrideDefinition?: OverrideFoundationElementDefinition<AnchorOptions> | undefined) => FoundationElementRegistry<AnchorOptions, Constructable<FoundationElement>>;
-    vsCodeOption: (overrideDefinition?: OverrideFoundationElementDefinition<ListboxOptionOptions> | undefined) => FoundationElementRegistry<ListboxOptionOptions, Constructable<FoundationElement>>;
+    vsCodeDropdown: (overrideDefinition?: OverrideFoundationElementDefinition<SelectOptions> | undefined) => FoundationElementRegistry<SelectOptions, typeof Dropdown>;
+    vsCodeLink: (overrideDefinition?: OverrideFoundationElementDefinition<AnchorOptions> | undefined) => FoundationElementRegistry<AnchorOptions, typeof Link>;
+    vsCodeOption: (overrideDefinition?: OverrideFoundationElementDefinition<ListboxOptionOptions> | undefined) => FoundationElementRegistry<ListboxOptionOptions, typeof Option_2>;
     vsCodePanels: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, typeof Panels>;
     vsCodePanelTab: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, typeof PanelTab>;
     vsCodePanelView: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, typeof PanelView>;
-    vsCodeProgressRing: (overrideDefinition?: OverrideFoundationElementDefinition<ProgressRingOptions> | undefined) => FoundationElementRegistry<ProgressRingOptions, Constructable<FoundationElement>>;
+    vsCodeProgressRing: (overrideDefinition?: OverrideFoundationElementDefinition<ProgressRingOptions> | undefined) => FoundationElementRegistry<ProgressRingOptions, typeof ProgressRing>;
     vsCodeRadioGroup: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, typeof RadioGroup>;
-    vsCodeRadio: (overrideDefinition?: OverrideFoundationElementDefinition<RadioOptions> | undefined) => FoundationElementRegistry<RadioOptions, Constructable<FoundationElement>>;
+    vsCodeRadio: (overrideDefinition?: OverrideFoundationElementDefinition<RadioOptions> | undefined) => FoundationElementRegistry<RadioOptions, typeof Radio>;
     vsCodeTag: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, typeof Tag>;
     vsCodeTextArea: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, typeof TextArea>;
-    vsCodeTextField: (overrideDefinition?: OverrideFoundationElementDefinition<TextFieldOptions> | undefined) => FoundationElementRegistry<TextFieldOptions, Constructable<FoundationElement>>;
+    vsCodeTextField: (overrideDefinition?: OverrideFoundationElementDefinition<TextFieldOptions> | undefined) => FoundationElementRegistry<TextFieldOptions, typeof TextField>;
     register(container?: Container | undefined, ...rest: any[]): void;
 };
 
@@ -189,10 +187,10 @@ export class TextField extends TextField_2 {
 export const vsCodeBadge: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, typeof Badge>;
 
 // @public
-export const vsCodeButton: (overrideDefinition?: OverrideFoundationElementDefinition<ButtonOptions> | undefined) => FoundationElementRegistry<ButtonOptions, Constructable<FoundationElement>>;
+export const vsCodeButton: (overrideDefinition?: OverrideFoundationElementDefinition<ButtonOptions> | undefined) => FoundationElementRegistry<ButtonOptions, typeof Button>;
 
 // @public
-export const vsCodeCheckbox: (overrideDefinition?: OverrideFoundationElementDefinition<CheckboxOptions> | undefined) => FoundationElementRegistry<CheckboxOptions, Constructable<FoundationElement>>;
+export const vsCodeCheckbox: (overrideDefinition?: OverrideFoundationElementDefinition<CheckboxOptions> | undefined) => FoundationElementRegistry<CheckboxOptions, typeof Checkbox>;
 
 // @public
 export const vsCodeDataGrid: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, typeof DataGrid>;
@@ -207,13 +205,13 @@ export const vsCodeDataGridRow: (overrideDefinition?: OverrideFoundationElementD
 export const vsCodeDivider: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, typeof Divider>;
 
 // @public
-export const vsCodeDropdown: (overrideDefinition?: OverrideFoundationElementDefinition<SelectOptions> | undefined) => FoundationElementRegistry<SelectOptions, Constructable<FoundationElement>>;
+export const vsCodeDropdown: (overrideDefinition?: OverrideFoundationElementDefinition<SelectOptions> | undefined) => FoundationElementRegistry<SelectOptions, typeof Dropdown>;
 
 // @public
-export const vsCodeLink: (overrideDefinition?: OverrideFoundationElementDefinition<AnchorOptions> | undefined) => FoundationElementRegistry<AnchorOptions, Constructable<FoundationElement>>;
+export const vsCodeLink: (overrideDefinition?: OverrideFoundationElementDefinition<AnchorOptions> | undefined) => FoundationElementRegistry<AnchorOptions, typeof Link>;
 
 // @public
-export const vsCodeOption: (overrideDefinition?: OverrideFoundationElementDefinition<ListboxOptionOptions> | undefined) => FoundationElementRegistry<ListboxOptionOptions, Constructable<FoundationElement>>;
+export const vsCodeOption: (overrideDefinition?: OverrideFoundationElementDefinition<ListboxOptionOptions> | undefined) => FoundationElementRegistry<ListboxOptionOptions, typeof Option_2>;
 
 // @public
 export const vsCodePanels: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, typeof Panels>;
@@ -225,10 +223,10 @@ export const vsCodePanelTab: (overrideDefinition?: OverrideFoundationElementDefi
 export const vsCodePanelView: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, typeof PanelView>;
 
 // @public
-export const vsCodeProgressRing: (overrideDefinition?: OverrideFoundationElementDefinition<ProgressRingOptions> | undefined) => FoundationElementRegistry<ProgressRingOptions, Constructable<FoundationElement>>;
+export const vsCodeProgressRing: (overrideDefinition?: OverrideFoundationElementDefinition<ProgressRingOptions> | undefined) => FoundationElementRegistry<ProgressRingOptions, typeof ProgressRing>;
 
 // @public
-export const vsCodeRadio: (overrideDefinition?: OverrideFoundationElementDefinition<RadioOptions> | undefined) => FoundationElementRegistry<RadioOptions, Constructable<FoundationElement>>;
+export const vsCodeRadio: (overrideDefinition?: OverrideFoundationElementDefinition<RadioOptions> | undefined) => FoundationElementRegistry<RadioOptions, typeof Radio>;
 
 // @public
 export const vsCodeRadioGroup: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, typeof RadioGroup>;
@@ -240,7 +238,7 @@ export const vsCodeTag: (overrideDefinition?: OverrideFoundationElementDefinitio
 export const vsCodeTextArea: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, typeof TextArea>;
 
 // @public
-export const vsCodeTextField: (overrideDefinition?: OverrideFoundationElementDefinition<TextFieldOptions> | undefined) => FoundationElementRegistry<TextFieldOptions, Constructable<FoundationElement>>;
+export const vsCodeTextField: (overrideDefinition?: OverrideFoundationElementDefinition<TextFieldOptions> | undefined) => FoundationElementRegistry<TextFieldOptions, typeof TextField>;
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/badge/index.ts
+++ b/src/badge/index.ts
@@ -3,6 +3,7 @@
 
 import {
 	Badge as FoundationBadge,
+	FoundationElementDefinition,
 	badgeTemplate as template,
 } from '@microsoft/fast-foundation';
 import {badgeStyles as styles} from './badge.styles';
@@ -39,7 +40,10 @@ export class Badge extends FoundationBadge {
  *
  * @public
  */
-export const vsCodeBadge = Badge.compose({
+export const vsCodeBadge = Badge.compose<
+	FoundationElementDefinition,
+	typeof Badge
+>({
 	baseName: 'badge',
 	template,
 	styles,

--- a/src/button/index.ts
+++ b/src/button/index.ts
@@ -93,7 +93,7 @@ export class Button extends FoundationButton {
  *
  * @public
  */
-export const vsCodeButton = Button.compose<ButtonOptions>({
+export const vsCodeButton = Button.compose<ButtonOptions, typeof Button>({
 	baseName: 'button',
 	template,
 	styles,

--- a/src/checkbox/index.ts
+++ b/src/checkbox/index.ts
@@ -39,7 +39,10 @@ export class Checkbox extends FoundationCheckbox {
  *
  * @public
  */
-export const vsCodeCheckbox = Checkbox.compose<CheckboxOptions>({
+export const vsCodeCheckbox = Checkbox.compose<
+	CheckboxOptions,
+	typeof Checkbox
+>({
 	baseName: 'checkbox',
 	template,
 	styles,

--- a/src/data-grid/index.ts
+++ b/src/data-grid/index.ts
@@ -6,6 +6,7 @@ import {
 	DataGrid as FoundationDataGrid,
 	DataGridCell as FoundationDataGridCell,
 	DataGridRow as FoundationDataGridRow,
+	FoundationElementDefinition,
 	dataGridTemplate as gridTemplate,
 	dataGridRowTemplate as rowTemplate,
 } from '@microsoft/fast-foundation';
@@ -45,7 +46,10 @@ export class DataGrid extends FoundationDataGrid {
  *
  * @public
  */
-export const vsCodeDataGrid = DataGrid.compose({
+export const vsCodeDataGrid = DataGrid.compose<
+	FoundationElementDefinition,
+	typeof DataGrid
+>({
 	baseName: 'data-grid',
 	baseClass: FoundationDataGrid,
 	template: gridTemplate,
@@ -67,7 +71,10 @@ export class DataGridRow extends FoundationDataGridRow {}
  *
  * @public
  */
-export const vsCodeDataGridRow = DataGridRow.compose({
+export const vsCodeDataGridRow = DataGridRow.compose<
+	FoundationElementDefinition,
+	typeof DataGridRow
+>({
 	baseName: 'data-grid-row',
 	baseClass: FoundationDataGridRow,
 	template: rowTemplate,
@@ -89,7 +96,10 @@ export class DataGridCell extends FoundationDataGridCell {}
  *
  * @public
  */
-export const vsCodeDataGridCell = DataGridCell.compose({
+export const vsCodeDataGridCell = DataGridCell.compose<
+	FoundationElementDefinition,
+	typeof DataGridCell
+>({
 	baseName: 'data-grid-cell',
 	baseClass: FoundationDataGridCell,
 	template: cellTemplate,

--- a/src/divider/index.ts
+++ b/src/divider/index.ts
@@ -3,6 +3,7 @@
 
 import {
 	Divider as FoundationDivider,
+	FoundationElementDefinition,
 	dividerTemplate as template,
 } from '@microsoft/fast-foundation';
 import {dividerStyles as styles} from './divider.styles';
@@ -22,7 +23,10 @@ export class Divider extends FoundationDivider {}
  *
  * @public
  */
-export const vsCodeDivider = Divider.compose({
+export const vsCodeDivider = Divider.compose<
+	FoundationElementDefinition,
+	typeof Divider
+>({
 	baseName: 'divider',
 	template,
 	styles,

--- a/src/dropdown/index.ts
+++ b/src/dropdown/index.ts
@@ -29,7 +29,10 @@ export class Dropdown extends FoundationSelect {}
  *
  * @public
  */
-export const vsCodeDropdown = Dropdown.compose<DropdownOptions>({
+export const vsCodeDropdown = Dropdown.compose<
+	DropdownOptions,
+	typeof Dropdown
+>({
 	baseName: 'dropdown',
 	template,
 	styles,

--- a/src/link/index.ts
+++ b/src/link/index.ts
@@ -29,7 +29,7 @@ export class Link extends FoundationAnchor {}
  *
  * @public
  */
-export const vsCodeLink = Link.compose<LinkOptions>({
+export const vsCodeLink = Link.compose<LinkOptions, typeof Link>({
 	baseName: 'link',
 	template,
 	styles,

--- a/src/option/index.ts
+++ b/src/option/index.ts
@@ -45,7 +45,7 @@ export class Option extends FoundationListboxOption {
  *
  * @public
  */
-export const vsCodeOption = Option.compose<OptionOptions>({
+export const vsCodeOption = Option.compose<OptionOptions, typeof Option>({
 	baseName: 'option',
 	template,
 	styles,

--- a/src/panels/index.ts
+++ b/src/panels/index.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import {
+	FoundationElementDefinition,
 	Tab as FoundationTab,
 	TabPanel as FoundationTabPanel,
 	Tabs as FoundationTabs,
@@ -53,7 +54,10 @@ export class Panels extends FoundationTabs {
  *
  * @public
  */
-export const vsCodePanels = Panels.compose({
+export const vsCodePanels = Panels.compose<
+	FoundationElementDefinition,
+	typeof Panels
+>({
 	baseName: 'panels',
 	template: tabsTemplate,
 	styles: panelsStyles,
@@ -95,7 +99,10 @@ export class PanelTab extends FoundationTab {
  *
  * @public
  */
-export const vsCodePanelTab = PanelTab.compose({
+export const vsCodePanelTab = PanelTab.compose<
+	FoundationElementDefinition,
+	typeof PanelTab
+>({
 	baseName: 'panel-tab',
 	template: tabTemplate,
 	styles: panelTabStyles,
@@ -116,7 +123,10 @@ export class PanelView extends FoundationTabPanel {}
  *
  * @public
  */
-export const vsCodePanelView = PanelView.compose({
+export const vsCodePanelView = PanelView.compose<
+	FoundationElementDefinition,
+	typeof PanelView
+>({
 	baseName: 'panel-view',
 	template: tabPanelTemplate,
 	styles: panelViewStyles,

--- a/src/progress-ring/index.ts
+++ b/src/progress-ring/index.ts
@@ -69,7 +69,10 @@ export class ProgressRing extends BaseProgress {
  *
  * @public
  */
-export const vsCodeProgressRing = ProgressRing.compose<ProgressRingOptions>({
+export const vsCodeProgressRing = ProgressRing.compose<
+	ProgressRingOptions,
+	typeof ProgressRing
+>({
 	baseName: 'progress-ring',
 	template,
 	styles,

--- a/src/radio-group/index.ts
+++ b/src/radio-group/index.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import {
+	FoundationElementDefinition,
 	RadioGroup as FoundationRadioGroup,
 	radioGroupTemplate as template,
 } from '@microsoft/fast-foundation';
@@ -40,7 +41,10 @@ export class RadioGroup extends FoundationRadioGroup {
  *
  * @public
  */
-export const vsCodeRadioGroup = RadioGroup.compose({
+export const vsCodeRadioGroup = RadioGroup.compose<
+	FoundationElementDefinition,
+	typeof RadioGroup
+>({
 	baseName: 'radio-group',
 	template,
 	styles,

--- a/src/radio/index.ts
+++ b/src/radio/index.ts
@@ -39,7 +39,7 @@ export class Radio extends FoundationRadio {
  *
  * @public
  */
-export const vsCodeRadio = Radio.compose<RadioOptions>({
+export const vsCodeRadio = Radio.compose<RadioOptions, typeof Radio>({
 	baseName: 'radio',
 	template,
 	styles,

--- a/src/tag/index.ts
+++ b/src/tag/index.ts
@@ -3,6 +3,7 @@
 
 import {
 	Badge as FoundationBadge,
+	FoundationElementDefinition,
 	badgeTemplate as template,
 } from '@microsoft/fast-foundation';
 import {tagStyles as styles} from './tag.styles';
@@ -39,7 +40,7 @@ export class Tag extends FoundationBadge {
  *
  * @public
  */
-export const vsCodeTag = Tag.compose({
+export const vsCodeTag = Tag.compose<FoundationElementDefinition, typeof Tag>({
 	baseName: 'tag',
 	template,
 	styles,

--- a/src/text-area/index.ts
+++ b/src/text-area/index.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import {
+	FoundationElementDefinition,
 	TextArea as FoundationTextArea,
 	textAreaTemplate as template,
 } from '@microsoft/fast-foundation';
@@ -41,7 +42,7 @@ export class TextArea extends FoundationTextArea {
  *
  * @public
  */
-export const vsCodeTextArea = TextArea.compose({
+export const vsCodeTextArea = TextArea.compose<FoundationElementDefinition, typeof TextArea>({
 	baseName: 'text-area',
 	template,
 	styles,

--- a/src/text-area/index.ts
+++ b/src/text-area/index.ts
@@ -42,7 +42,10 @@ export class TextArea extends FoundationTextArea {
  *
  * @public
  */
-export const vsCodeTextArea = TextArea.compose<FoundationElementDefinition, typeof TextArea>({
+export const vsCodeTextArea = TextArea.compose<
+	FoundationElementDefinition,
+	typeof TextArea
+>({
 	baseName: 'text-area',
 	template,
 	styles,

--- a/src/text-field/index.ts
+++ b/src/text-field/index.ts
@@ -39,7 +39,10 @@ export class TextField extends FoundationTextField {
  *
  * @public
  */
-export const vsCodeTextField = TextField.compose<TextFieldOptions>({
+export const vsCodeTextField = TextField.compose<
+	TextFieldOptions,
+	typeof TextField
+>({
 	baseName: 'text-field',
 	template,
 	styles,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests and/or Storybook stories for your feature or bug fix.
-->

### Link to relevant issue

This pull request resolves #289 

### Description of changes

Fixes an issue with component registration functions where type information was being lost in certain cases. This caused downstream problems when used with the `fast-react-wrapper` so that component attributes had incomplete type info and rendered the component unusable in TypeScript-based React projects.

Reference [this issue](https://github.com/microsoft/fast/issues/5387) for even more background context on this problem/solution.