### PR TITLE
Add `type` attribute info to text field docs

### DIFF
--- a/src/text-field/README.md
+++ b/src/text-field/README.md
@@ -13,6 +13,7 @@ The `vscode-text-field` is a web component implementation of a [text field eleme
 | `placeholder` | string  | Sets the placeholder value of the component, generally used to provide a hint to the user. |
 | `readonly`    | boolean | When true, the control will be immutable by any user interaction.                          |
 | `size`        | number  | Sets the width of the element to a specified number of characters.                         |
+| `type`        | string  | Sets the text field type from a set of options.                                            |
 | `value`       | string  | The value (i.e. content) of the text field.                                                |
 
 ## Usage
@@ -81,6 +82,20 @@ The `vscode-text-field` is a web component implementation of a [text field eleme
 
 ```html
 <vscode-text-field size="50">Text Field Label</vscode-text-field>
+```
+
+### Type Attribute
+
+Sets the text field type. Valid options include: "email", "password", "tel", "text", and "url". The default value is "text".
+
+[Interactive Storybook Example](https://microsoft.github.io/vscode-webview-ui-toolkit/?path=/story/library-text-field--with-type)
+
+```html
+<vscode-text-field type="email">Text Field Label</vscode-text-field>
+<vscode-text-field type="password">Text Field Label</vscode-text-field>
+<vscode-text-field type="tel">Text Field Label</vscode-text-field>
+<vscode-text-field type="text">Text Field Label</vscode-text-field>
+<vscode-text-field type="url">Text Field Label</vscode-text-field>
 ```
 
 ### Start Icon

--- a/src/text-field/README.md
+++ b/src/text-field/README.md
@@ -13,7 +13,7 @@ The `vscode-text-field` is a web component implementation of a [text field eleme
 | `placeholder` | string  | Sets the placeholder value of the component, generally used to provide a hint to the user. |
 | `readonly`    | boolean | When true, the control will be immutable by any user interaction.                          |
 | `size`        | number  | Sets the width of the element to a specified number of characters.                         |
-| `type`        | string  | Sets the text field type from a set of options.                                            |
+| `type`        | string  | Sets the text field type.                                                                  |
 | `value`       | string  | The value (i.e. content) of the text field.                                                |
 
 ## Usage

--- a/src/text-field/fixtures/createTextField.ts
+++ b/src/text-field/fixtures/createTextField.ts
@@ -4,12 +4,15 @@
 import {TextField} from '../index';
 import {createCodiconIcon} from '../../utilities/storybook/index';
 
+type TextFieldType = 'email' | 'password' | 'tel' | 'text' | 'url';
+
 export type TextFieldArgs = {
 	label: string;
 	placeholder: string;
 	value: string;
 	maxLength: number;
 	size: number;
+	type: TextFieldType;
 	isReadOnly: boolean;
 	isDisabled: boolean;
 	isAutoFocused: boolean;
@@ -23,6 +26,7 @@ export function createTextField({
 	value,
 	maxLength,
 	size,
+	type,
 	isReadOnly,
 	isDisabled,
 	isAutoFocused,
@@ -45,6 +49,9 @@ export function createTextField({
 	}
 	if (size) {
 		textField.setAttribute('size', size.toString());
+	}
+	if (type) {
+		textField.setAttribute('type', type.toLowerCase());
 	}
 	if (isReadOnly) {
 		textField.setAttribute('readonly', '');

--- a/src/text-field/text-field.stories.ts
+++ b/src/text-field/text-field.stories.ts
@@ -11,6 +11,12 @@ export default {
 		value: {control: 'text'},
 		maxLength: {control: 'number'},
 		size: {control: 'number'},
+		type: {
+			control: {
+				type: 'select',
+				options: ['Email', 'Password', 'Tel', 'Text', 'Url'],
+			},
+		},
 		isReadOnly: {control: 'boolean'},
 		isDisabled: {control: 'boolean'},
 		isAutoFocused: {control: 'boolean'},
@@ -35,6 +41,7 @@ Default.args = {
 	value: '',
 	maxLength: '',
 	size: '',
+	type: 'Text',
 	isReadOnly: false,
 	isDisabled: false,
 	isAutoFocused: false,
@@ -99,6 +106,19 @@ WithCustomSize.parameters = {
 	docs: {
 		source: {
 			code: `<vscode-text-field size="50">Text Field Label</vscode-text-field>`,
+		},
+	},
+};
+
+export const WithType: any = Template.bind({});
+WithType.args = {
+	...Default.args,
+	type: 'Text',
+};
+WithType.parameters = {
+	docs: {
+		source: {
+			code: `<vscode-text-field type="email">Text Field Label</vscode-text-field>\n<vscode-text-field type="password">Text Field Label</vscode-text-field>\n<vscode-text-field type="tel">Text Field Label</vscode-text-field>\n<vscode-text-field type="text">Text Field Label</vscode-text-field>\n<vscode-text-field type="url">Text Field Label</vscode-text-field>`,
 		},
 	},
 };


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests and/or Storybook stories for your feature or bug fix.
-->

### Link to relevant issue

This pull request resolves #306

### Description of changes

Add some basic documentation and a Storybook story for the text field component `type` attribute.