### PR TITLE
Export fast foundation component attribute enums

### DIFF
--- a/docs/api-report.md
+++ b/docs/api-report.md
@@ -15,17 +15,23 @@ import { CheckboxOptions } from '@microsoft/fast-foundation';
 import type { Container } from '@microsoft/fast-foundation';
 import { DataGrid as DataGrid_2 } from '@microsoft/fast-foundation';
 import { DataGridCell as DataGridCell_2 } from '@microsoft/fast-foundation';
+import { DataGridCellTypes } from '@microsoft/fast-foundation';
 import { DataGridRow as DataGridRow_2 } from '@microsoft/fast-foundation';
+import { DataGridRowTypes } from '@microsoft/fast-foundation';
 import { DesignSystem } from '@microsoft/fast-foundation';
 import { Divider as Divider_2 } from '@microsoft/fast-foundation';
+import { DividerRole } from '@microsoft/fast-foundation';
+import { SelectPosition as DropdownPosition } from '@microsoft/fast-foundation';
 import { FoundationElementDefinition } from '@microsoft/fast-foundation';
 import { FoundationElementRegistry } from '@microsoft/fast-foundation';
+import { GenerateHeaderOptions } from '@microsoft/fast-foundation';
 import { ListboxOption } from '@microsoft/fast-foundation';
 import { ListboxOptionOptions } from '@microsoft/fast-foundation';
 import { OverrideFoundationElementDefinition } from '@microsoft/fast-foundation';
 import { ProgressRingOptions } from '@microsoft/fast-foundation';
 import { Radio as Radio_2 } from '@microsoft/fast-foundation';
 import { RadioGroup as RadioGroup_2 } from '@microsoft/fast-foundation';
+import { Orientation as RadioGroupOrientation } from '@microsoft/fast-web-utilities';
 import { RadioOptions } from '@microsoft/fast-foundation';
 import { Select } from '@microsoft/fast-foundation';
 import { SelectOptions } from '@microsoft/fast-foundation';
@@ -33,8 +39,10 @@ import { Tab } from '@microsoft/fast-foundation';
 import { TabPanel } from '@microsoft/fast-foundation';
 import { Tabs } from '@microsoft/fast-foundation';
 import { TextArea as TextArea_2 } from '@microsoft/fast-foundation';
+import { TextAreaResize } from '@microsoft/fast-foundation';
 import { TextField as TextField_2 } from '@microsoft/fast-foundation';
 import { TextFieldOptions } from '@microsoft/fast-foundation';
+import { TextFieldType } from '@microsoft/fast-foundation';
 
 // @public
 export const allComponents: {
@@ -94,13 +102,19 @@ export class DataGrid extends DataGrid_2 {
 export class DataGridCell extends DataGridCell_2 {
 }
 
+export { DataGridCellTypes }
+
 // @public
 export class DataGridRow extends DataGridRow_2 {
 }
 
+export { DataGridRowTypes }
+
 // @public
 export class Divider extends Divider_2 {
 }
+
+export { DividerRole }
 
 // @public
 export class Dropdown extends Select {
@@ -108,6 +122,10 @@ export class Dropdown extends Select {
 
 // @public
 export type DropdownOptions = SelectOptions;
+
+export { DropdownPosition }
+
+export { GenerateHeaderOptions }
 
 // @public
 export class Link extends Anchor {
@@ -165,6 +183,8 @@ export class RadioGroup extends RadioGroup_2 {
     connectedCallback(): void;
 }
 
+export { RadioGroupOrientation }
+
 // @public
 export class Tag extends Badge_2 {
     // @internal
@@ -177,11 +197,15 @@ export class TextArea extends TextArea_2 {
     connectedCallback(): void;
 }
 
+export { TextAreaResize }
+
 // @public
 export class TextField extends TextField_2 {
     // @internal
     connectedCallback(): void;
 }
+
+export { TextFieldType }
 
 // @public
 export const vsCodeBadge: (overrideDefinition?: OverrideFoundationElementDefinition<FoundationElementDefinition> | undefined) => FoundationElementRegistry<FoundationElementDefinition, typeof Badge>;

--- a/src/data-grid/index.ts
+++ b/src/data-grid/index.ts
@@ -3,16 +3,21 @@
 
 import {
 	dataGridCellTemplate as cellTemplate,
+	DataGridCellTypes,
+	DataGridRowTypes,
 	DataGrid as FoundationDataGrid,
 	DataGridCell as FoundationDataGridCell,
 	DataGridRow as FoundationDataGridRow,
 	FoundationElementDefinition,
+	GenerateHeaderOptions,
 	dataGridTemplate as gridTemplate,
 	dataGridRowTemplate as rowTemplate,
 } from '@microsoft/fast-foundation';
 import {dataGridStyles as gridStyles} from './data-grid.styles';
 import {dataGridRowStyles as rowStyles} from './data-grid-row.styles';
 import {dataGridCellStyles as cellStyles} from './data-grid-cell.styles';
+
+export {DataGridCellTypes, DataGridRowTypes, GenerateHeaderOptions};
 
 /**
  * The Visual Studio Code data grid class.

--- a/src/divider/index.ts
+++ b/src/divider/index.ts
@@ -2,11 +2,14 @@
 // Licensed under the MIT License.
 
 import {
+	DividerRole,
 	Divider as FoundationDivider,
 	FoundationElementDefinition,
 	dividerTemplate as template,
 } from '@microsoft/fast-foundation';
 import {dividerStyles as styles} from './divider.styles';
+
+export {DividerRole};
 
 /**
  * The Visual Studio Code divider class.

--- a/src/dropdown/index.ts
+++ b/src/dropdown/index.ts
@@ -2,14 +2,14 @@
 // Licensed under the MIT License.
 
 import {
+	SelectPosition as DropdownPosition,
 	Select as FoundationSelect,
 	SelectOptions,
-	SelectPosition,
 	selectTemplate as template,
 } from '@microsoft/fast-foundation';
 import {dropdownStyles as styles} from './dropdown.styles';
 
-export {SelectPosition as DropdownPosition};
+export {DropdownPosition};
 
 /**
  * Dropdown configuration options

--- a/src/dropdown/index.ts
+++ b/src/dropdown/index.ts
@@ -4,9 +4,12 @@
 import {
 	Select as FoundationSelect,
 	SelectOptions,
+	SelectPosition,
 	selectTemplate as template,
 } from '@microsoft/fast-foundation';
 import {dropdownStyles as styles} from './dropdown.styles';
+
+export {SelectPosition as DropdownPosition};
 
 /**
  * Dropdown configuration options

--- a/src/radio-group/index.ts
+++ b/src/radio-group/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import {Orientation} from '@microsoft/fast-web-utilities';
+import {Orientation as RadioGroupOrientation} from '@microsoft/fast-web-utilities';
 import {
 	FoundationElementDefinition,
 	RadioGroup as FoundationRadioGroup,
@@ -9,7 +9,7 @@ import {
 } from '@microsoft/fast-foundation';
 import {radioGroupStyles as styles} from './radio-group.styles';
 
-export {Orientation as RadioGroupOrientation};
+export {RadioGroupOrientation};
 
 /**
  * The Visual Studio Code radio group class.

--- a/src/radio-group/index.ts
+++ b/src/radio-group/index.ts
@@ -1,12 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import {Orientation} from '@microsoft/fast-web-utilities';
 import {
 	FoundationElementDefinition,
 	RadioGroup as FoundationRadioGroup,
 	radioGroupTemplate as template,
 } from '@microsoft/fast-foundation';
 import {radioGroupStyles as styles} from './radio-group.styles';
+
+export {Orientation as RadioGroupOrientation};
 
 /**
  * The Visual Studio Code radio group class.

--- a/src/text-area/index.ts
+++ b/src/text-area/index.ts
@@ -5,8 +5,11 @@ import {
 	FoundationElementDefinition,
 	TextArea as FoundationTextArea,
 	textAreaTemplate as template,
+	TextAreaResize,
 } from '@microsoft/fast-foundation';
 import {textAreaStyles as styles} from './text-area.styles';
+
+export {TextAreaResize};
 
 /**
  * The Visual Studio Code text area class.

--- a/src/text-field/index.ts
+++ b/src/text-field/index.ts
@@ -5,8 +5,11 @@ import {
 	TextField as FoundationTextField,
 	textFieldTemplate as template,
 	TextFieldOptions,
+	TextFieldType,
 } from '@microsoft/fast-foundation';
 import {textFieldStyles as styles} from './text-field.styles';
+
+export {TextFieldType};
 
 /**
  * The Visual Studio Code text field class.


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests and/or Storybook stories for your feature or bug fix.
-->

### Description of changes

This is a temporary stop-gap solution to this [upstream issue](https://github.com/microsoft/fast/issues/5494) where a handful of toolkit component attributes (when wrapped as React components) will result in TS type errors because the attributes/props require an enum as the value.

Once the upstream issue is resolved these changes should be reverted.