### PR TITLE
Fix misnamed link design tokens

### DIFF
--- a/src/design-tokens.ts
+++ b/src/design-tokens.ts
@@ -102,8 +102,8 @@ export const inputPlaceholderForeground = create<string>('input-placeholder-fore
  * Link design tokens.
  */
 
-export const linkActiveForeground = create<string>('link-foreground', '--vscode-textLink-activeForeground').withDefault('#3794ff');
-export const linkForeground = create<string>('link-active-foreground', '--vscode-textLink-foreground').withDefault('#3794ff');
+export const linkActiveForeground = create<string>('link-active-foreground', '--vscode-textLink-activeForeground').withDefault('#3794ff');
+export const linkForeground = create<string>('link-foreground', '--vscode-textLink-foreground').withDefault('#3794ff');
 
 /**
  * Progress ring design tokens.


### PR DESCRIPTION
The active and foreground tokens names were swapped. I don't think this affects the VS Code scenario, because the tokens are referred to by their correct TypeScript identifiers, but it breaks custom theming that overrides the CSS variables.