### PR TITLE
Set disabled according to new value of attribute

### DIFF
--- a/src/button/index.ts
+++ b/src/button/index.ts
@@ -80,7 +80,7 @@ export class Button extends FoundationButton {
 		}
 
 		if (attrName === 'disabled') {
-			this.disabled = true;
+			this.disabled = newVal !== null;
 		}
 	}
 }


### PR DESCRIPTION
Rather than force disabling it.

<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests and/or Storybook stories for your feature or bug fix.
-->

### Link to relevant issue

### Description of changes

Without this change, setting the disabled attribute using `setAttribute` or `removeAttribute` doesn't work on firefox. This can be demostrated using the following html
```html
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8">
  <script type="module" src="dist/toolkit.js"></script>
</head>
<body>
  <vscode-button id="btn">btn-0</vscode-button>
  <vscode-button id="btn2">btn2</vscode-button>
  <script>
      enabled = true;
      counter = 0;
      btn = document.getElementById('btn');
      btn2 = document.getElementById('btn2');
      function onclick() {
          btn.innerHTML = `btn-${++counter}`;
          enabled = !enabled;
          if (enabled) {
              btn.removeAttribute('disabled');
          }
          else {
              btn.setAttribute('disabled', '');
          }
      }
      btn.addEventListener('click', onclick);
      btn2.addEventListener('click', onclick);
  </script>
</body>
</html>
```
Clicking on either button should toggle the disable state of the first button. This works in chromium (and therefore the native version of vscode). However, on firefox, as soon as this happens, even when enabled, the first button isn't clickable anymore (clicking has no effect) (which happens for online version of vscode when used in firefox).

I'm not sure how this was supposed to work but the code here looks wrong to me. The callback is called (on both firefox and chromium) when the attribute is changed but it seems to just assume any change in the value is adding the attribute which is only the case for the initial setup.

Even though this is setting the wrong value, it works in chromium because `formDisabledCallback` from `FormAssociated` is called with the right disabled value. It appears that this callback isn't called on firefox and I'm not sure why (I assume some expected browser differences...)...

### Link to forked docs site

<!--
  If component changes (especially visual changes) are contained in this PR, we ask that you provide a link to a publicly viewable version of the Storybook docs site so PR reviewers can see your changes without having to install and view your code locally.

  Please see `CONTRIBUTING.md` for directions on how this can be done.
-->
