### PR TITLE
Fix light theme a11y bug in focused data grid cells

### DIFF
--- a/src/data-grid/data-grid-cell.styles.ts
+++ b/src/data-grid/data-grid-cell.styles.ts
@@ -50,4 +50,9 @@ export const dataGridCellStyles = (
 		color: ${listActiveSelectionForeground};
 		outline: none;
 	}
+	:host(:${focusVisible}) ::slotted(*),
+	:host(:focus) ::slotted(*),
+	:host(:active) ::slotted(*) {
+		color: ${listActiveSelectionForeground} !important;
+	}
 `;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests and/or Storybook stories for your feature or bug fix.
-->

### Link to relevant issue

This pull request resolves #277 and #278

### Description of changes

Add the `listActiveSelectionForeground` color token to all slotted content in data grid cells. This resolves a bug in VS Code light themes where the color of slotted elements in data grid cells did not have high enough contrast with the background when focused/active.

**Before**

![image](https://user-images.githubusercontent.com/39639992/156276285-5f4e9744-cb54-46b6-a01e-c04f0e027982.png)
![image](https://user-images.githubusercontent.com/39639992/156276305-db5cb382-17d2-4397-a28d-c42898bc54e6.png)

**After**

<img width="992" alt="Screen Shot 2022-03-01 at 5 16 43 PM" src="https://user-images.githubusercontent.com/39639992/156276337-d897dcd2-1d8a-40d9-8998-2f81c4c732c7.png">
<img width="994" alt="Screen Shot 2022-03-01 at 5 16 50 PM" src="https://user-images.githubusercontent.com/39639992/156276342-5077f9c8-3abf-46d2-adf9-108929ea1084.png">

