### PR TITLE
fix: remove max-width to fix uncentered text

### DIFF
--- a/src/button/button.styles.ts
+++ b/src/button/button.styles.ts
@@ -85,7 +85,6 @@ const BaseButtonStyles = css`
 		fill: inherit;
 		cursor: inherit;
 		font-family: inherit;
-		max-width: 300px;
 	}
 	:host(:hover) {
 		background: ${buttonPrimaryHoverBackground};


### PR DESCRIPTION
### Link to relevant issue

This pull request resolves #384 

### Test 
set width of div to 500px then set vs-code button width to 100%

![Extension Development Host  Component Gallery - Visual Studio Code](https://user-images.githubusercontent.com/30198386/181885398-986e9710-8f97-47f2-af96-761374b9e7ee.jpg)

### Description of changes

removed max-width in button style to fix uncentered text/icons when width is greater than 300px
