### PR TITLE
Fix link word break issue (Fix #388)

### DIFF
--- a/src/link/link.styles.ts
+++ b/src/link/link.styles.ts
@@ -47,6 +47,7 @@ export const linkStyles = (
 		padding: 0;
 		outline: none;
 		text-decoration: none;
+		word-break: break-word;
 	}
 	.control::-moz-focus-inner {
 		border: 0;

--- a/src/link/link.styles.ts
+++ b/src/link/link.styles.ts
@@ -47,7 +47,6 @@ export const linkStyles = (
 		padding: 0;
 		outline: none;
 		text-decoration: none;
-		white-space: nowrap;
 	}
 	.control::-moz-focus-inner {
 		border: 0;


### PR DESCRIPTION
Fixes #388 by removing `white-space: nowrap` and adding `word-break: break-word` rule to allow links using long continuous strings to break into new lines.

## Before
<img width="350" alt="CleanShot 2022-08-05 at 09 38 17@2x" src="https://user-images.githubusercontent.com/25163139/183122565-232ec43c-a7d6-4299-84f7-cffa216bfbe2.png">

## After
<img width="350" alt="CleanShot 2022-08-05 at 09 37 33@2x" src="https://user-images.githubusercontent.com/25163139/183122583-25edc927-5ce6-4718-9218-234732af8d22.png">

