### PR TITLE
Fix `vscode-link` focus regression

### DIFF
--- a/src/link/link.styles.ts
+++ b/src/link/link.styles.ts
@@ -62,7 +62,8 @@ export const linkStyles = (
 		background: transparent;
 		color: ${linkActiveForeground};
 	}
-	:host(:${focusVisible}) .control {
+	:host(:${focusVisible}) .control,
+	:host(:focus) .control {
 		border: calc(${borderWidth} * 1px) solid ${focusBorder};
 	}
 `;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests and/or Storybook stories for your feature or bug fix.
-->

### Link to relevant issue

This pull request resolves #398 

### Description of changes

Add a new CSS selector to fix `vscode-link` focus regression where the link focus border was not being rendered when tab-based focus was given.
