### PR TITLE
Data grid: same overflow wrap on headers and cells.

### DIFF
--- a/src/data-grid/data-grid-cell.styles.ts
+++ b/src/data-grid/data-grid-cell.styles.ts
@@ -40,7 +40,6 @@ export const dataGridCellStyles = (
 	}
 	:host(.column-header) {
 		font-weight: 600;
-		overflow-wrap: normal;
 	}
 	:host(:${focusVisible}),
 	:host(:focus),


### PR DESCRIPTION
### Link to relevant issue

This pull request resolves #411

### Description of changes

Headers and cells are assigned a different [overflow wrap](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap):
- headers have an overflow wrap set to `normal` [here](https://github.com/microsoft/vscode-webview-ui-toolkit/blob/main/src/data-grid/data-grid-cell.styles.ts#L43)
- cells have it set to `anywhere` [here](https://github.com/microsoft/vscode-webview-ui-toolkit/blob/main/src/data-grid/data-grid-cell.styles.ts#L39)

As a result headers only break at normal break points (e.g. a space) whereas cells do not. Applying the same overflow wrap to both would resolve the issue.
