### PR TITLE
Add docs for multiple icons in text fields

### DIFF
--- a/src/text-field/README.md
+++ b/src/text-field/README.md
@@ -147,3 +147,34 @@ An icon can be added to the right of the text field by adding an element with th
   <span slot="end" class="codicon codicon-chevron-right"></span>
 </vscode-text-field>
 ```
+
+### Slotted Content
+
+Building on top of the icon examples, it's worth noting that any arbitrary HTML can be inserted into the start and end slots of a text field with the `slot="start"` and `slot="end"` attributes.
+
+The below example demonstrate how the native search text field from VS Code might be _visually_ implemented with a `section` tag that wraps a few `vscode-buttons` with an icon appearance applied (please note that further behavior is needed to make this functional).
+
+**❗️ An important note ❗️**
+
+While component slots provide a lot of flexibility to extend components please use them responsibly and remember to follow the extension [UX Guidelines](https://code.visualstudio.com/api/ux-guidelines/overview) to ensure that your extension UI still has the same look and feel as the rest of VS Code.
+
+[Interactive Storybook Example](https://microsoft.github.io/vscode-webview-ui-toolkit/?path=/story/library-text-field--with-slotted-content)
+
+```html
+<!-- Note: Using Visual Studio Code Codicon Library -->
+
+<vscode-text-field>
+  Text Field Label
+  <section slot="end" style="display:flex; align-items: center;">
+    <vscode-button appearance="icon" aria-label="Toggle case sensitive search">
+      <span class="codicon codicon-case-sensitive"></span>
+    </vscode-button>
+    <vscode-button appearance="icon" aria-label="Toggle whole word search">
+      <span class="codicon codicon-whole-word"></span>
+    </vscode-button>
+    <vscode-button appearance="icon" aria-label="Toggle regex search">
+      <span class="codicon codicon-regex"></span>
+    </vscode-button>
+  </section>
+</vscode-text-field>
+```

--- a/src/text-field/README.md
+++ b/src/text-field/README.md
@@ -148,17 +148,13 @@ An icon can be added to the right of the text field by adding an element with th
 </vscode-text-field>
 ```
 
-### Slotted Content
+### Multiple Icons
 
-Building on top of the icon examples, it's worth noting that any arbitrary HTML can be inserted into the start and end slots of a text field with the `slot="start"` and `slot="end"` attributes.
+Building on top of the icon examples above, multiple icons can also be inserted into the start and end slots of a text field with the `slot="start"` and `slot="end"` attributes.
 
-The below example demonstrate how the native search text field from VS Code might be _visually_ implemented with a `section` tag that wraps a few `vscode-buttons` with an icon appearance applied (please note that further JavaScript is needed to make this example functional).
+The below example demonstrate how the native search text field from VS Code might be _visually_ implemented with a `section` tag that wraps a few `vscode-buttons` with an icon appearance applied (please note that further JavaScript is needed to make this example functional, however).
 
-**❗️ An important note ❗️**
-
-While component slots provide a lot of flexibility to extend components please use them responsibly and remember to follow the extension [UX Guidelines](https://code.visualstudio.com/api/ux-guidelines/overview) to ensure that your extension UI still has the same look and feel as the rest of VS Code.
-
-[Interactive Storybook Example](https://microsoft.github.io/vscode-webview-ui-toolkit/?path=/story/library-text-field--with-slotted-content)
+[Interactive Storybook Example](https://microsoft.github.io/vscode-webview-ui-toolkit/?path=/story/library-text-field--with-multiple-icons)
 
 ```html
 <!-- Note: Using Visual Studio Code Codicon Library -->
@@ -166,13 +162,13 @@ While component slots provide a lot of flexibility to extend components please u
 <vscode-text-field>
   Text Field Label
   <section slot="end" style="display:flex; align-items: center;">
-    <vscode-button appearance="icon" aria-label="Toggle case sensitive search">
+    <vscode-button appearance="icon" aria-label="Match Case">
       <span class="codicon codicon-case-sensitive"></span>
     </vscode-button>
-    <vscode-button appearance="icon" aria-label="Toggle whole word search">
+    <vscode-button appearance="icon" aria-label="Match Whole Word">
       <span class="codicon codicon-whole-word"></span>
     </vscode-button>
-    <vscode-button appearance="icon" aria-label="Toggle regex search">
+    <vscode-button appearance="icon" aria-label="Use Regular Expression">
       <span class="codicon codicon-regex"></span>
     </vscode-button>
   </section>

--- a/src/text-field/README.md
+++ b/src/text-field/README.md
@@ -152,7 +152,7 @@ An icon can be added to the right of the text field by adding an element with th
 
 Building on top of the icon examples, it's worth noting that any arbitrary HTML can be inserted into the start and end slots of a text field with the `slot="start"` and `slot="end"` attributes.
 
-The below example demonstrate how the native search text field from VS Code might be _visually_ implemented with a `section` tag that wraps a few `vscode-buttons` with an icon appearance applied (please note that further behavior is needed to make this functional).
+The below example demonstrate how the native search text field from VS Code might be _visually_ implemented with a `section` tag that wraps a few `vscode-buttons` with an icon appearance applied (please note that further JavaScript is needed to make this example functional).
 
 **❗️ An important note ❗️**
 

--- a/src/text-field/README.md
+++ b/src/text-field/README.md
@@ -152,7 +152,7 @@ An icon can be added to the right of the text field by adding an element with th
 
 Building on top of the icon examples above, multiple icons can also be inserted into the start and end slots of a text field with the `slot="start"` and `slot="end"` attributes.
 
-The below example demonstrate how the native search text field from VS Code might be _visually_ implemented with a `section` tag that wraps a few `vscode-buttons` with an icon appearance applied (please note that further JavaScript is needed to make this example functional, however).
+The below example demonstrates how the native search text field from VS Code might be _visually_ implemented with a `section` tag that wraps a few `vscode-buttons` with an icon appearance applied (please note that further JavaScript is needed to make this example functional, however).
 
 [Interactive Storybook Example](https://microsoft.github.io/vscode-webview-ui-toolkit/?path=/story/library-text-field--with-multiple-icons)
 

--- a/src/text-field/fixtures/createTextField.ts
+++ b/src/text-field/fixtures/createTextField.ts
@@ -18,7 +18,7 @@ export type TextFieldArgs = {
 	isAutoFocused: boolean;
 	startIcon: boolean;
 	endIcon: boolean;
-	slottedContent: boolean;
+	multipleIcons: boolean;
 };
 
 export function createTextField({
@@ -33,7 +33,7 @@ export function createTextField({
 	isAutoFocused,
 	startIcon,
 	endIcon,
-	slottedContent,
+	multipleIcons,
 }: TextFieldArgs) {
 	const textField = new TextField();
 
@@ -75,20 +75,20 @@ export function createTextField({
 		const end = createCodiconIcon({iconName: 'text-size', slotName: 'end'});
 		textField.appendChild(end);
 	}
-	if (slottedContent) {
+	if (multipleIcons) {
 		const section = document.createElement('section');
 		section.setAttribute('slot', 'end');
 		section.style.display = 'flex';
 		section.style.alignItems = 'center';
 
 		section.innerHTML = /*html*/ `
-			<vscode-button appearance="icon" aria-label="Toggle case sensitive search">
+			<vscode-button appearance="icon" aria-label="Match Case">
 					<span class="codicon codicon-case-sensitive"></span>
 			</vscode-button>
-			<vscode-button appearance="icon" aria-label="Toggle whole word search">
+			<vscode-button appearance="icon" aria-label="Match Whole Word">
 					<span class="codicon codicon-whole-word"></span>
 			</vscode-button>
-			<vscode-button appearance="icon" aria-label="Toggle regex search">
+			<vscode-button appearance="icon" aria-label="Use Regular Expression">
 					<span class="codicon codicon-regex"></span>
 			</vscode-button>
 		`;

--- a/src/text-field/fixtures/createTextField.ts
+++ b/src/text-field/fixtures/createTextField.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import {TextField} from '../index';
+import {Button, ButtonAppearance} from '../../index';
 import {createCodiconIcon} from '../../utilities/storybook/index';
 
 type TextFieldType = 'email' | 'password' | 'tel' | 'text' | 'url';
@@ -18,6 +19,7 @@ export type TextFieldArgs = {
 	isAutoFocused: boolean;
 	startIcon: boolean;
 	endIcon: boolean;
+	slottedContent: boolean;
 };
 
 export function createTextField({
@@ -32,6 +34,7 @@ export function createTextField({
 	isAutoFocused,
 	startIcon,
 	endIcon,
+	slottedContent,
 }: TextFieldArgs) {
 	const textField = new TextField();
 
@@ -72,6 +75,26 @@ export function createTextField({
 	if (endIcon) {
 		const end = createCodiconIcon({iconName: 'text-size', slotName: 'end'});
 		textField.appendChild(end);
+	}
+	if (slottedContent) {
+		const section = document.createElement('section');
+		section.setAttribute('slot', 'end');
+		section.style.display = 'flex';
+		section.style.alignItems = 'center';
+
+		section.innerHTML = /*html*/ `
+			<vscode-button appearance="icon" aria-label="Toggle case sensitive search">
+					<span class="codicon codicon-case-sensitive"></span>
+			</vscode-button>
+			<vscode-button appearance="icon" aria-label="Toggle whole word search">
+					<span class="codicon codicon-whole-word"></span>
+			</vscode-button>
+			<vscode-button appearance="icon" aria-label="Toggle regex search">
+					<span class="codicon codicon-regex"></span>
+			</vscode-button>
+		`;
+
+		textField.appendChild(section);
 	}
 
 	return textField;

--- a/src/text-field/fixtures/createTextField.ts
+++ b/src/text-field/fixtures/createTextField.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import {TextField} from '../index';
-import {Button, ButtonAppearance} from '../../index';
 import {createCodiconIcon} from '../../utilities/storybook/index';
 
 type TextFieldType = 'email' | 'password' | 'tel' | 'text' | 'url';

--- a/src/text-field/text-field.stories.ts
+++ b/src/text-field/text-field.stories.ts
@@ -22,7 +22,7 @@ export default {
 		isAutoFocused: {control: 'boolean'},
 		startIcon: {control: 'boolean'},
 		endIcon: {control: 'boolean'},
-		slottedContent: {control: 'boolean'},
+		multipleIcons: {control: 'boolean'},
 	},
 	parameters: {
 		actions: {
@@ -48,7 +48,7 @@ Default.args = {
 	isAutoFocused: false,
 	startIcon: false,
 	endIcon: false,
-	slottedContent: false,
+	multipleIcons: false,
 };
 Default.parameters = {
 	docs: {
@@ -180,15 +180,15 @@ WithEndIcon.parameters = {
 	},
 };
 
-export const WithSlottedContent: any = Template.bind({});
-WithSlottedContent.args = {
+export const WithMultipleIcons: any = Template.bind({});
+WithMultipleIcons.args = {
 	...Default.args,
-	slottedContent: true,
+	multipleIcons: true,
 };
-WithSlottedContent.parameters = {
+WithMultipleIcons.parameters = {
 	docs: {
 		source: {
-			code: `<!-- Note: Using Visual Studio Code Codicon Library -->\n\n<vscode-text-field>\n\tText Field Label\n\t<section slot="end" style="display:flex; align-items: center;">\n\t\t<vscode-button appearance="icon" aria-label="Toggle case sensitive search">\n\t\t\t<span class="codicon codicon-case-sensitive"></span>\n\t\t</vscode-button>\n\t\t<vscode-button appearance="icon" aria-label="Toggle whole word search">\n\t\t\t<span class="codicon codicon-whole-word"></span>\n\t\t</vscode-button>\n\t\t<vscode-button appearance="icon" aria-label="Toggle regex search">\n\t\t\t<span class="codicon codicon-regex"></span>\n\t\t</vscode-button>\n\t</section>\n</vscode-text-field>`,
+			code: `<!-- Note: Using Visual Studio Code Codicon Library -->\n\n<vscode-text-field>\n\tText Field Label\n\t<section slot="end" style="display:flex; align-items: center;">\n\t\t<vscode-button appearance="icon" aria-label="Match Case">\n\t\t\t<span class="codicon codicon-case-sensitive"></span>\n\t\t</vscode-button>\n\t\t<vscode-button appearance="icon" aria-label="Match Whole Word">\n\t\t\t<span class="codicon codicon-whole-word"></span>\n\t\t</vscode-button>\n\t\t<vscode-button appearance="icon" aria-label="Use Regular Expression">\n\t\t\t<span class="codicon codicon-regex"></span>\n\t\t</vscode-button>\n\t</section>\n</vscode-text-field>`,
 		},
 	},
 };

--- a/src/text-field/text-field.stories.ts
+++ b/src/text-field/text-field.stories.ts
@@ -22,6 +22,7 @@ export default {
 		isAutoFocused: {control: 'boolean'},
 		startIcon: {control: 'boolean'},
 		endIcon: {control: 'boolean'},
+		slottedContent: {control: 'boolean'},
 	},
 	parameters: {
 		actions: {
@@ -47,6 +48,7 @@ Default.args = {
 	isAutoFocused: false,
 	startIcon: false,
 	endIcon: false,
+	slottedContent: false,
 };
 Default.parameters = {
 	docs: {
@@ -174,6 +176,19 @@ WithEndIcon.parameters = {
 	docs: {
 		source: {
 			code: `<!-- Note: Using Visual Studio Code Codicon Library -->\n\n<vscode-text-field>\n\tText Field Label\n\t<span slot="end" class="codicon codicon-text-size"></span>\n</vscode-text-field>`,
+		},
+	},
+};
+
+export const WithSlottedContent: any = Template.bind({});
+WithSlottedContent.args = {
+	...Default.args,
+	slottedContent: true,
+};
+WithSlottedContent.parameters = {
+	docs: {
+		source: {
+			code: `<!-- Note: Using Visual Studio Code Codicon Library -->\n\n<vscode-text-field>\n\tText Field Label\n\t<section slot="end" style="display:flex; align-items: center;">\n\t\t<vscode-button appearance="icon" aria-label="Toggle case sensitive search">\n\t\t\t<span class="codicon codicon-case-sensitive"></span>\n\t\t</vscode-button>\n\t\t<vscode-button appearance="icon" aria-label="Toggle whole word search">\n\t\t\t<span class="codicon codicon-whole-word"></span>\n\t\t</vscode-button>\n\t\t<vscode-button appearance="icon" aria-label="Toggle regex search">\n\t\t\t<span class="codicon codicon-regex"></span>\n\t\t</vscode-button>\n\t</section>\n</vscode-text-field>`,
 		},
 	},
 };


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests and/or Storybook stories for your feature or bug fix.
-->

### Link to relevant issue

This pull request resolves #307 

### Description of changes

Adds documentation and Storybook sample explaining how text field slots can be used to create something like the native search text field in VS Code.
