### PR TITLE
Fix HC light buttons using the wrong hover background

### DIFF
--- a/src/utilities/theme/applyTheme.ts
+++ b/src/utilities/theme/applyTheme.ts
@@ -64,6 +64,25 @@ function applyCurrentTheme(tokenMappings: Map<string, CSSDesignToken<T>>) {
 				if (toolkitToken.name === 'button-icon-hover-background') {
 					value = 'transparent';
 				}
+			} else if (themeKind === 'vscode-high-contrast-light') {
+				if (
+					value.length === 0 &&
+					toolkitToken.name.includes('background')
+				) {
+					// Set button variant hover backgrounds to correct values based on VS Code core source:
+					// https://github.com/microsoft/vscode/blob/fd0ee4f77e354de10ae591c9e97fe5ad41b398fc/src/vs/platform/theme/common/colorRegistry.ts#L270-L276
+					switch (toolkitToken.name) {
+						case 'button-primary-hover-background':
+							value = '#0F4A85';
+							break;
+						case 'button-secondary-hover-background':
+							value = 'transparent';
+							break;
+						case 'button-icon-hover-background':
+							value = 'transparent';
+							break;
+					}
+				}
 			} else {
 				// Set contrast-active-border token to be transparent in non-high-contrast themes
 				if (toolkitToken.name === 'contrast-active-border') {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests and/or Storybook stories for your feature or bug fix.
-->

### Link to relevant issue

This pull request resolves #365 

### Description of changes

Fix high contrast light theme issue where the wrong colors were being applied to buttons on hover.
