### PR TITLE
Fix code snippet in getting started guide

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -157,7 +157,7 @@ With the `dispose` method defined, you also need to update the constructor metho
 private constructor(panel: vscode.WebviewPanel) {
     // ... other code ...
 
-    this._panel.onDidDispose(this.dispose, null, this._disposables);
+    this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
 }
 ```
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests and/or Storybook stories for your feature or bug fix.
-->

### Link to relevant issue

This pull request is associated with [a bug filed in the toolkit sample repo](https://github.com/microsoft/vscode-webview-ui-toolkit-samples/issues/122)

### Description of changes

Updates a code snippet from the getting started guide that demonstrated an improper way of disposing of webview panel resources when the panel is closed.
