### PR TITLE
fix(docs): prefer ESM exports of dependencies when bundling with esbuild

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -61,6 +61,7 @@ const baseConfig = {
 const extensionConfig = {
   ...baseConfig,
   platform: "node",
+  mainFields: ["module", "main"],
   format: "cjs",
   entryPoints: ["./src/extension.ts"],
   outfile: "./out/extension.js",


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests and/or Storybook stories for your feature or bug fix.
-->

### Link to relevant issue

This pull request resolves #

### Description of changes

When following the getting started guide, I got stuck because `esbuild` seems to prefer the UMD exports of some transpiled modules. Those can not be statically analyzed and cause runtime errors for missing dependencies - in my case `vscode-json-languageservice` and some of its dependencies.

By telling `esbuild` to prefer the `module` field over `main`, this issue gets avoided.
