### PR TITLE
fix: fix typos in divider and radio group readmes

### DIFF
--- a/src/divider/README.md
+++ b/src/divider/README.md
@@ -1,6 +1,6 @@
 # Visual Studio Code Divider
 
-The `vscode-divider` is a web component implementation of a [horiztonal rule element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr).
+The `vscode-divider` is a web component implementation of a [horizontal rule element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr).
 
 ![Divider hero](/docs/assets/images/divider-hero.png)
 

--- a/src/radio-group/README.md
+++ b/src/radio-group/README.md
@@ -33,7 +33,7 @@ While any DOM content is permissible as a child of the `vscode-radio-group`, onl
 | ------------- | ------- | -------------------------------------------------------------------------------------------- |
 | `disabled`    | boolean | Disables the radio group and child radios.                                                   |
 | `name`        | string  | The name of the radio group. This will also set the name value for all child radio elements. |
-| `orientation` | string  | The orientation of the group. Options: `horiztonal`, `vertical`.                             |
+| `orientation` | string  | The orientation of the group. Options: `horizontal`, `vertical`.                             |
 | `readonly`    | boolean | When true, the child radios will be immutable by user interaction.                           |
 
 ### Basic Radio Group


### PR DESCRIPTION
### Link to relevant issue

n/a

### Description of changes

This fixes two typos found in the documentation
