### PR TITLE
Bump @microsoft/fast-* dependencies to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
 			"version": "1.2.2",
 			"license": "MIT",
 			"dependencies": {
-				"@microsoft/fast-element": "^1.6.2",
-				"@microsoft/fast-foundation": "^2.38.0",
-				"@microsoft/fast-react-wrapper": "^0.1.18"
+				"@microsoft/fast-element": "^1.12.0",
+				"@microsoft/fast-foundation": "^2.49.0",
+				"@microsoft/fast-react-wrapper": "^0.3.18"
 			},
 			"devDependencies": {
 				"@microsoft/api-extractor": "7.18.9",
@@ -367,17 +367,17 @@
 			}
 		},
 		"node_modules/@microsoft/fast-element": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.8.0.tgz",
-			"integrity": "sha512-92GhkCYcay+vcI2yE+P1yD+v59u8Thprmaqg9PgTstf8jLOrevW/6Hna76tMioQQOFtZ8wm2NiiMHD/4sjrfhQ=="
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.12.0.tgz",
+			"integrity": "sha512-gQutuDHPKNxUEcQ4pypZT4Wmrbapus+P9s3bR/SEOLsMbNqNoXigGImITygI5zhb+aA5rzflM6O8YWkmRbGkPA=="
 		},
 		"node_modules/@microsoft/fast-foundation": {
-			"version": "2.38.0",
-			"resolved": "https://registry.npmjs.org/@microsoft/fast-foundation/-/fast-foundation-2.38.0.tgz",
-			"integrity": "sha512-jD907wwTMJzXltch234GFHKxnn+ycbZQor7kFolb3Ij6PXqGTUotUEqRrZpiECp7T522t5pYxi305cYc7HQ/ZA==",
+			"version": "2.49.0",
+			"resolved": "https://registry.npmjs.org/@microsoft/fast-foundation/-/fast-foundation-2.49.0.tgz",
+			"integrity": "sha512-Wk4e4QXFVtT5hPwhMfHyGY30kixM0td8aDs7bAD6NM2z2SCBNvpTTWp+FCjx0I0lpUMlMenb6wsw7pMWQreRkQ==",
 			"dependencies": {
-				"@microsoft/fast-element": "^1.8.0",
-				"@microsoft/fast-web-utilities": "^5.1.0",
+				"@microsoft/fast-element": "^1.12.0",
+				"@microsoft/fast-web-utilities": "^5.4.1",
 				"tabbable": "^5.2.0",
 				"tslib": "^1.13.0"
 			}
@@ -388,23 +388,23 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/@microsoft/fast-react-wrapper": {
-			"version": "0.1.18",
-			"resolved": "https://registry.npmjs.org/@microsoft/fast-react-wrapper/-/fast-react-wrapper-0.1.18.tgz",
-			"integrity": "sha512-xKLNWW+dvd+GAzEmq4DKTikKvOgKVHdLdRoWgmMpKXGD+d4eYf39O5yI3wZoSxKFz7tWv51dYXHnHVMIkzAGgw==",
+			"version": "0.3.18",
+			"resolved": "https://registry.npmjs.org/@microsoft/fast-react-wrapper/-/fast-react-wrapper-0.3.18.tgz",
+			"integrity": "sha512-lHXs+JZZItUyb48ZAMTRCnIryMVg6H+Hs/CuQGmjwMWcze0vqffpYq4eOZ03YSRjLU11oDfMGNbl5kvHC2ZdmQ==",
 			"dependencies": {
-				"@microsoft/fast-element": "^1.6.2",
-				"@microsoft/fast-foundation": "^2.27.2"
+				"@microsoft/fast-element": "^1.12.0",
+				"@microsoft/fast-foundation": "^2.49.0"
 			},
 			"peerDependencies": {
 				"react": ">=16.9.0"
 			}
 		},
 		"node_modules/@microsoft/fast-web-utilities": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@microsoft/fast-web-utilities/-/fast-web-utilities-5.1.0.tgz",
-			"integrity": "sha512-S2PCxI4XqtIxLM1N7i/NuIAgx+mJM01+mDzyB3vZlYibAkOT0bzp5YZCp+coXowokSin/nK5T2kqShMXEzI6Jg==",
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/@microsoft/fast-web-utilities/-/fast-web-utilities-5.4.1.tgz",
+			"integrity": "sha512-ReWYncndjV3c8D8iq9tp7NcFNc1vbVHvcBFPME2nNFKNbS1XCesYZGlIlf3ot5EmuOXPlrzUHOWzQ2vFpIkqDg==",
 			"dependencies": {
-				"exenv-es6": "^1.0.0"
+				"exenv-es6": "^1.1.1"
 			}
 		},
 		"node_modules/@microsoft/tsdoc": {
@@ -2516,9 +2516,9 @@
 			}
 		},
 		"node_modules/exenv-es6": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/exenv-es6/-/exenv-es6-1.0.0.tgz",
-			"integrity": "sha512-fcG/TX8Ruv9Ma6PBaiNsUrHRJzVzuFMP6LtPn/9iqR+nr9mcLeEOGzXQGLC5CVQSXGE98HtzW2mTZkrCA3XrDg=="
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/exenv-es6/-/exenv-es6-1.1.1.tgz",
+			"integrity": "sha512-vlVu3N8d6yEMpMsEm+7sUBAI81aqYYuEvfK0jNqmdb/OPXzzH7QWDDnVjMvDSY47JdHEqx/dfC/q8WkfoTmpGQ=="
 		},
 		"node_modules/extend": {
 			"version": "3.0.2",
@@ -6077,17 +6077,17 @@
 			}
 		},
 		"@microsoft/fast-element": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.8.0.tgz",
-			"integrity": "sha512-92GhkCYcay+vcI2yE+P1yD+v59u8Thprmaqg9PgTstf8jLOrevW/6Hna76tMioQQOFtZ8wm2NiiMHD/4sjrfhQ=="
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.12.0.tgz",
+			"integrity": "sha512-gQutuDHPKNxUEcQ4pypZT4Wmrbapus+P9s3bR/SEOLsMbNqNoXigGImITygI5zhb+aA5rzflM6O8YWkmRbGkPA=="
 		},
 		"@microsoft/fast-foundation": {
-			"version": "2.38.0",
-			"resolved": "https://registry.npmjs.org/@microsoft/fast-foundation/-/fast-foundation-2.38.0.tgz",
-			"integrity": "sha512-jD907wwTMJzXltch234GFHKxnn+ycbZQor7kFolb3Ij6PXqGTUotUEqRrZpiECp7T522t5pYxi305cYc7HQ/ZA==",
+			"version": "2.49.0",
+			"resolved": "https://registry.npmjs.org/@microsoft/fast-foundation/-/fast-foundation-2.49.0.tgz",
+			"integrity": "sha512-Wk4e4QXFVtT5hPwhMfHyGY30kixM0td8aDs7bAD6NM2z2SCBNvpTTWp+FCjx0I0lpUMlMenb6wsw7pMWQreRkQ==",
 			"requires": {
-				"@microsoft/fast-element": "^1.8.0",
-				"@microsoft/fast-web-utilities": "^5.1.0",
+				"@microsoft/fast-element": "^1.12.0",
+				"@microsoft/fast-web-utilities": "^5.4.1",
 				"tabbable": "^5.2.0",
 				"tslib": "^1.13.0"
 			},
@@ -6100,20 +6100,20 @@
 			}
 		},
 		"@microsoft/fast-react-wrapper": {
-			"version": "0.1.18",
-			"resolved": "https://registry.npmjs.org/@microsoft/fast-react-wrapper/-/fast-react-wrapper-0.1.18.tgz",
-			"integrity": "sha512-xKLNWW+dvd+GAzEmq4DKTikKvOgKVHdLdRoWgmMpKXGD+d4eYf39O5yI3wZoSxKFz7tWv51dYXHnHVMIkzAGgw==",
+			"version": "0.3.18",
+			"resolved": "https://registry.npmjs.org/@microsoft/fast-react-wrapper/-/fast-react-wrapper-0.3.18.tgz",
+			"integrity": "sha512-lHXs+JZZItUyb48ZAMTRCnIryMVg6H+Hs/CuQGmjwMWcze0vqffpYq4eOZ03YSRjLU11oDfMGNbl5kvHC2ZdmQ==",
 			"requires": {
-				"@microsoft/fast-element": "^1.6.2",
-				"@microsoft/fast-foundation": "^2.27.2"
+				"@microsoft/fast-element": "^1.12.0",
+				"@microsoft/fast-foundation": "^2.49.0"
 			}
 		},
 		"@microsoft/fast-web-utilities": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@microsoft/fast-web-utilities/-/fast-web-utilities-5.1.0.tgz",
-			"integrity": "sha512-S2PCxI4XqtIxLM1N7i/NuIAgx+mJM01+mDzyB3vZlYibAkOT0bzp5YZCp+coXowokSin/nK5T2kqShMXEzI6Jg==",
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/@microsoft/fast-web-utilities/-/fast-web-utilities-5.4.1.tgz",
+			"integrity": "sha512-ReWYncndjV3c8D8iq9tp7NcFNc1vbVHvcBFPME2nNFKNbS1XCesYZGlIlf3ot5EmuOXPlrzUHOWzQ2vFpIkqDg==",
 			"requires": {
-				"exenv-es6": "^1.0.0"
+				"exenv-es6": "^1.1.1"
 			}
 		},
 		"@microsoft/tsdoc": {
@@ -7757,9 +7757,9 @@
 			"dev": true
 		},
 		"exenv-es6": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/exenv-es6/-/exenv-es6-1.0.0.tgz",
-			"integrity": "sha512-fcG/TX8Ruv9Ma6PBaiNsUrHRJzVzuFMP6LtPn/9iqR+nr9mcLeEOGzXQGLC5CVQSXGE98HtzW2mTZkrCA3XrDg=="
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/exenv-es6/-/exenv-es6-1.1.1.tgz",
+			"integrity": "sha512-vlVu3N8d6yEMpMsEm+7sUBAI81aqYYuEvfK0jNqmdb/OPXzzH7QWDDnVjMvDSY47JdHEqx/dfC/q8WkfoTmpGQ=="
 		},
 		"extend": {
 			"version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
 		"test:webview-react": "npm run build && node ./scripts/setup-webview-react-test-env.js"
 	},
 	"dependencies": {
-		"@microsoft/fast-element": "^1.6.2",
-		"@microsoft/fast-foundation": "^2.38.0",
-		"@microsoft/fast-react-wrapper": "^0.1.18"
+		"@microsoft/fast-element": "^1.12.0",
+		"@microsoft/fast-foundation": "^2.49.0",
+		"@microsoft/fast-react-wrapper": "^0.3.18"
 	},
 	"peerDependencies": {
 		"react": ">=16.9.0"


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.
-->

### Link to relevant issue

This pull request resolves #494 

### Description of changes

Bumped the versions of the @microsoft/fast dependencies to the following latest versions.

`"@microsoft/fast-element": "^1.12.0",
"@microsoft/fast-foundation": "^2.49.0",
"@microsoft/fast-react-wrapper": "^0.3.18"`

This should resolve the issue mentioned above as the @microsoft/fast-react-wrapper is now configured to be of type: module