### PR TITLE
Add editable data grid section to docs

### DIFF
--- a/src/data-grid/README.md
+++ b/src/data-grid/README.md
@@ -307,6 +307,6 @@ basicGrid.columnDefinitions = [
 
 Interactive/editable data grids are a highly requested feature in the Webview UI Toolkit.
 
-By default, the toolkit and in particular [FAST](https://www.fast.design/) (the underlying framework that the toolkit uses) **do not** offer any first-party APIs for enabling interactivity or editability in data grids. Additionally, since FAST owns the underlying data grid implementation, first-party support for interactivity will eventually need to come from them. 
+By default, the toolkit and in particular [FAST](https://www.fast.design/) (the underlying framework that the toolkit uses) **do not** offer any first-party APIs for enabling interactivity or editability in data grids. Additionally, since FAST owns the underlying data grid implementation, first-party support for interactivity will eventually need to come from them.
 
 With that said, workaround solutions are possible and a reference implementation for making the `vscode-data-grid` component editable is [available as a sample extension](https://github.com/microsoft/vscode-webview-ui-toolkit-samples/tree/main/default/editable-data-grid).

--- a/src/data-grid/README.md
+++ b/src/data-grid/README.md
@@ -302,3 +302,11 @@ basicGrid.columnDefinitions = [
   { columnDataKey: "ColumnKey4", title: "Custom Title" },
 ];
 ```
+
+## Editable Data Grid
+
+Interactive/editable data grids are a highly requested feature in the Webview UI Toolkit.
+
+By default, the toolkit and in particular [FAST](https://www.fast.design/) (the underlying framework that the toolkit uses) **do not** offer any first-party APIs for enabling interactivity or editability in data grids. Additionally, since FAST owns the underlying data grid implementation, first-party support for interactivity will eventually need to come from them. 
+
+With that said, workaround solutions are possible and a reference implementation for making the `vscode-data-grid` component editable is [available as a sample extension](https://github.com/microsoft/vscode-webview-ui-toolkit-samples/tree/main/default/editable-data-grid).


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.
-->

### Link to relevant issue

This pull request resolves #493 
Related to https://github.com/microsoft/vscode-webview-ui-toolkit-samples/pull/154

### Description of changes

Adds a new section to the data grid docs explaining the current state of the world for editable data grids and provides a link to the [editable data grid sample extension](https://github.com/microsoft/vscode-webview-ui-toolkit-samples/tree/main/default/editable-data-grid).
