### PR TITLE
Update `typescript` to `v4.6.2`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
 				"rollup-plugin-terser": "^7.0.2",
 				"rollup-plugin-transform-tagged-template": "0.0.3",
 				"tslib": "^2.1.0",
-				"typescript": "4.3.5"
+				"typescript": "^4.6.2"
 			},
 			"peerDependencies": {
 				"react": ">=16.9.0"
@@ -5660,9 +5660,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.3.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-			"integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+			"integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -10196,9 +10196,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.3.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-			"integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+			"integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
 			"dev": true
 		},
 		"unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"rollup-plugin-terser": "^7.0.2",
 		"rollup-plugin-transform-tagged-template": "0.0.3",
 		"tslib": "^2.1.0",
-		"typescript": "4.3.5"
+		"typescript": "^4.6.2"
 	},
 	"keywords": [
 		"vscode",


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.
-->

### Link to relevant issue

This pull request resolves #514 

### Description of changes

Updates `typescript` package to `v4.6.2`. This is the latest stable version of typescript that can be installed without conflicting with versions of typescript used in other dependencies.

Namely, the latest stable release of `@microsoft/eslint-config-fast-dna` requires typescript versions to be `~3.9.0 || ~4.3.5 || ^4.6.2`.