### PR TITLE
Add `tslib` as production dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
 			"dependencies": {
 				"@microsoft/fast-element": "^1.12.0",
 				"@microsoft/fast-foundation": "^2.49.4",
-				"@microsoft/fast-react-wrapper": "^0.3.22"
+				"@microsoft/fast-react-wrapper": "^0.3.22",
+				"tslib": "^2.6.2"
 			},
 			"devDependencies": {
 				"@microsoft/api-extractor": "^7.38.4",
@@ -30,7 +31,6 @@
 				"rollup-plugin-filesize": "^9.1.1",
 				"rollup-plugin-terser": "^7.0.2",
 				"rollup-plugin-transform-tagged-template": "0.0.3",
-				"tslib": "^2.1.0",
 				"typescript": "^4.6.2"
 			},
 			"peerDependencies": {
@@ -5547,10 +5547,9 @@
 			}
 		},
 		"node_modules/tslib": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-			"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-			"dev": true
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/tunnel-agent": {
 			"version": "0.6.0",
@@ -10113,10 +10112,9 @@
 			}
 		},
 		"tslib": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-			"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-			"dev": true
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
 	"dependencies": {
 		"@microsoft/fast-element": "^1.12.0",
 		"@microsoft/fast-foundation": "^2.49.4",
-		"@microsoft/fast-react-wrapper": "^0.3.22"
+		"@microsoft/fast-react-wrapper": "^0.3.22",
+		"tslib": "^2.6.2"
 	},
 	"peerDependencies": {
 		"react": ">=16.9.0"
@@ -53,7 +54,6 @@
 		"rollup-plugin-filesize": "^9.1.1",
 		"rollup-plugin-terser": "^7.0.2",
 		"rollup-plugin-transform-tagged-template": "0.0.3",
-		"tslib": "^2.1.0",
 		"typescript": "^4.6.2"
 	},
 	"keywords": [


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.
-->

### Link to relevant issue

This pull request resolves #451

### Description of changes

Fixes error discovered in some package managers (namely yarn) that was complaining that `tslib` could not be resolved.

Also bumps `tslib` version from `2.1.0` to `2.6.2`.
