### PR TITLE
Fixes #539 Checkbox shrinks when parent container shrinks

### DIFF
--- a/src/checkbox/checkbox.styles.ts
+++ b/src/checkbox/checkbox.styles.ts
@@ -21,6 +21,7 @@ import {
 	foreground,
 	typeRampBaseFontSize,
 	typeRampBaseLineHeight,
+	typeRampPlus1FontSize,
 } from '../design-tokens.js';
 
 export const checkboxStyles = (
@@ -60,6 +61,8 @@ export const checkboxStyles = (
 	.checked-indicator {
 		width: 100%;
 		height: 100%;
+		min-width: ${typeRampPlus1FontSize};
+		min-height: ${typeRampPlus1FontSize};
 		display: block;
 		fill: ${foreground};
 		opacity: 0;

--- a/src/checkbox/checkbox.styles.ts
+++ b/src/checkbox/checkbox.styles.ts
@@ -21,7 +21,6 @@ import {
 	foreground,
 	typeRampBaseFontSize,
 	typeRampBaseLineHeight,
-	typeRampPlus1FontSize,
 } from '../design-tokens.js';
 
 export const checkboxStyles = (
@@ -61,8 +60,8 @@ export const checkboxStyles = (
 	.checked-indicator {
 		width: 100%;
 		height: 100%;
-		min-width: ${typeRampPlus1FontSize};
-		min-height: ${typeRampPlus1FontSize};
+		min-width: calc(${designUnit} * 4px);
+		min-height: calc(${designUnit} * 4px);
 		display: block;
 		fill: ${foreground};
 		opacity: 0;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.
-->

### Link to relevant issue

This pull request resolves #539 

### Description of changes

<!-- Include a description of the proposed changes. -->
The width and height inherited from the parent container will override the `width: 16` and `height: 16` in the `<svg>`. If the parent container makes the checkbox shrink below 16px, the size will be skewed. Adding `mid-width` and `min-height` will prevent this to happen.

https://github.com/microsoft/vscode-webview-ui-toolkit/assets/7075677/75b5b7c0-afe7-4ed7-955c-6ddc5b702f16

